### PR TITLE
Add watermarks to full-view lightbox images

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,3 +7,4 @@
 - [ ] Investigate accessibility improvements
 - [ ] Data-table-ify admin
 - [ ] Help mum migrate from Twitter to Bluesky/Mastodon + investigate site integration
+- [ ] Improve initial page load performance - can we lazy load images further down the page?

--- a/app/views/blogs/_gallery.html.erb
+++ b/app/views/blogs/_gallery.html.erb
@@ -1,6 +1,6 @@
 <% attachments.each do |a| %>
   <% next if a.id.nil? %>
-  <%= link_to url_for(a.image.variant(resize_to_limit: [2048, 2048])), class: 'lightbox', data: { lightbox_target: 'item', caption: a.title.presence || a.alt_text } do %>
+  <%= link_to url_for(a.image.variant(resize_to_limit: [2048, 2048], watermark: true)), class: 'lightbox', data: { lightbox_target: 'item', caption: a.title.presence || a.alt_text } do %>
     <%= image_tag a.image.variant(resize_to_fill: [250, 250]),
           srcset: "#{url_for(a.image.variant(resize_to_fill: [250, 250]))} 1x, #{url_for(a.image.variant(resize_to_fill: [500, 500]))} 2x",
           alt: a.alt_text %>

--- a/config/initializers/image_processing.rb
+++ b/config/initializers/image_processing.rb
@@ -1,0 +1,29 @@
+# Custom Active Storage variant transformer for watermarking
+Rails.application.config.to_prepare do
+  ActiveStorage::Transformers::ImageProcessingTransformer.class_eval do
+    private
+
+    # Override operations to support watermark option
+    alias_method :original_operations, :operations
+
+    def operations
+      ops = original_operations
+
+      if transformations[:watermark]
+        # Add watermark as custom MiniMagick operations
+        ops = ops.custom do |img|
+          img.combine_options do |c|
+            c.gravity "SouthEast"
+            c.fill "rgba(255,255,255,0.4)"
+            c.stroke "rgba(0,0,0,0.2)"
+            c.strokewidth "1"
+            c.pointsize "18"
+            c.annotate "+15+15", "katescuttings.net"
+          end
+        end
+      end
+
+      ops
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add "katescuttings.net" text watermark to full-size lightbox images
- Creates custom Active Storage variant transformer
- Semi-transparent white text with dark stroke for visibility on any background
- Positioned in bottom-right corner
- Only applies to lightbox images, thumbnails remain clean

## Test plan
- [ ] Open a blog post with images
- [ ] Click an image to open the lightbox
- [ ] Verify watermark appears in bottom-right of full-size image
- [ ] Verify thumbnails do NOT have watermarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)