### PR TITLE
Add rake tasks for watermark variant management

### DIFF
--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -1,0 +1,48 @@
+namespace :images do
+  desc "Regenerate watermarked variants for all attachments"
+  task regenerate_watermarks: :environment do
+    # Delete existing watermarked variants so they get regenerated
+    count = 0
+
+    Attachment.includes(image_attachment: :blob).find_each do |attachment|
+      next unless attachment.image.attached?
+
+      # The watermarked variant key includes the watermark option
+      # We need to delete any existing variants and let them regenerate
+      blob = attachment.image.blob
+
+      # Delete variant records for this blob (they'll regenerate on next request)
+      if blob.variant_records.any?
+        blob.variant_records.destroy_all
+        count += 1
+        puts "Cleared variants for attachment ##{attachment.id}"
+      end
+    end
+
+    puts "Done! Cleared variants for #{count} attachments."
+    puts "Watermarked versions will be generated on next view."
+  end
+
+  desc "Pre-generate watermarked variants for all attachments"
+  task pregenerate_watermarks: :environment do
+    count = 0
+    errors = 0
+
+    Attachment.includes(image_attachment: :blob).find_each do |attachment|
+      next unless attachment.image.attached?
+
+      begin
+        # Generate the watermarked variant
+        variant = attachment.image.variant(resize_to_limit: [2048, 2048], watermark: true)
+        variant.processed
+        count += 1
+        puts "Generated watermark for attachment ##{attachment.id}"
+      rescue StandardError => e
+        errors += 1
+        puts "Error processing attachment ##{attachment.id}: #{e.message}"
+      end
+    end
+
+    puts "Done! Generated #{count} watermarked variants (#{errors} errors)."
+  end
+end


### PR DESCRIPTION
## Summary
- Add `images:regenerate_watermarks` - clears existing variants so they regenerate with watermarks
- Add `images:pregenerate_watermarks` - pre-generates all watermarked variants

## Usage
```bash
# Clear old variants (they'll regenerate on next view)
bin/rails images:regenerate_watermarks

# Or pre-generate all watermarks now
bin/rails images:pregenerate_watermarks
```

## Test plan
- [ ] Run `bin/rails images:regenerate_watermarks` locally
- [ ] View an image in lightbox to confirm watermark appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)