### PR TITLE
Add libyaml-dev for psych gem in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
     build-essential \
     git \
-    libpq-dev && \
+    libpq-dev \
+    libyaml-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install gems


### PR DESCRIPTION
## Summary

Fixes deploy failure caused by Ruby 3.4 upgrade. The `psych` gem now needs to be compiled from source and requires `libyaml-dev` in the Docker build stage.

## Test plan

- [ ] Docker build succeeds
- [ ] Deploy completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)